### PR TITLE
Add an external syntastic checker.

### DIFF
--- a/syntax/pony.vim
+++ b/syntax/pony.vim
@@ -8,6 +8,13 @@ if exists("b:current_syntax")
   finish
 endif
 
+" For syntastic as the 'pony' filetype is not officially registered.
+if exists('g:syntastic_extra_filetypes')
+    call add(g:syntastic_extra_filetypes, 'pony')
+else
+    let g:syntastic_extra_filetypes = ['pony']
+endif
+
 " TODO add markdown to triple-comments
 
 syn case match

--- a/syntax_checkers/pony/ponyc.vim
+++ b/syntax_checkers/pony/ponyc.vim
@@ -1,0 +1,46 @@
+"============================================================================
+"File:        ponyc.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Earnestly
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_pony_ponyc_checker')
+    finish
+endif
+let g:loaded_syntastic_pony_ponyc_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_pony_ponyc_GetLocList() dict
+
+    " This is currently a hack.  `ponyc` itself uses the project directory as
+    " the target to build.  Using expand like this fetches the parent
+    " directory of the current file which might cause supurious errors on
+    " package imports if the current file is nested under a sub-directory.
+    let n = expand('%:p:h')
+
+    " NOTE: The `-p /usr/lib/pony` flag is a downstream (Arch Linux) change
+    " which installs the standard packages to this location.  This should be
+    " fixed upstream soon: <https://github.com/CausalityLtd/ponyc/issues/172>
+    let makeprg = self.makeprgBuild({
+                \ 'args': '-p /usr/lib/pony --pass=expr',
+                \ 'fname': n})
+
+    let errorformat =
+                \ '%f:%l:%c: %m'
+
+    return SyntasticMake({
+                \ 'makeprg': makeprg,
+                \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+            \ 'filetype': 'pony',
+            \ 'name': 'ponyc'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
This patch adds an [external](https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external) syntastic checker as pony is still experimental.

Once pony is more stable and has better OS integration it could be
supported in syntastic.

See: https://github.com/scrooloose/syntastic/pull/1413
